### PR TITLE
add certify to requirements, adapt restapi_client_async

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pymodbus>=3.0.0,<4.0.0
 setuptools>=68.0.0,<69.0.0
 xsdata>=22.0.0,<23.0.0
 aiohttp>=3.0.0,<4.0.0
+certifi

--- a/sgr_library/restapi_client_async.py
+++ b/sgr_library/restapi_client_async.py
@@ -11,6 +11,8 @@ import logging
 
 from sgr_library.data_classes.product import DeviceFrame
 
+import ssl
+import certifi
 
 logging.basicConfig(level=logging.ERROR)
 
@@ -22,7 +24,9 @@ class SgrRestInterface():
 
     def __init__(self, xml_file, config_file_path):
         # session
-        self.session = aiohttp.ClientSession()
+        self.ssl_context = ssl.create_default_context(cafile=certifi.where())
+        self.connector = aiohttp.TCPConnector(ssl=self.ssl_context)
+        self.session = aiohttp.ClientSession(connector=self.connector)
         self.token = None
 
         try:


### PR DESCRIPTION
After upgrading to this commit, please install the certify python module
`$ pip install certifi`