### PR TITLE
http request cache to improve performance

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ setuptools>=68.0.0,<69.0.0
 xsdata>=22.0.0,<23.0.0
 aiohttp>=3.0.0,<4.0.0
 certifi
+cachetools>=5.0.0,<6.0.0

--- a/sgr_library/restapi_client_async.py
+++ b/sgr_library/restapi_client_async.py
@@ -102,9 +102,16 @@ class SgrRestInterface(BaseSGrInterface):
                self.root.interface_list.rest_api_interface.functional_profile_list.functional_profile_list_element]
         self._function_profiles = {fp.name(): fp for fp in fps}
         try:
-            user = configuration.get('AUTHENTICATION', 'username', fallback="test_user")
-            password = configuration.get('AUTHENTICATION', 'password', fallback="test_pw")
-            self.sensor_id = configuration.get('RESSOURCE', 'sensor_id', fallback="5e8c91ce9e720119f94d0249")
+            user, password = 'test', 'test_pw'
+            for section_name, section in configuration.items():
+                for param_name in section:
+                    if param_name == 'username':
+                        user = configuration.get(section_name, param_name)
+                    if param_name == 'password':
+                        password = configuration.get(section_name, param_name)
+
+                    if param_name == 'sensor_id':
+                        self.sensor_id = configuration.get(section_name, param_name)
 
             if not user:
                 raise ValueError("Missing username in the configuration file")


### PR DESCRIPTION
Added TTL cache to cache http calls for a certain (5 seconds) amount of time. This will improve performance as only one call to the api will be performant when many datapoint are request in a short time. 

I also made some changes to how certain parameter from the INI file configuration are parsed to insure that it is possible to read the required parameters from the XML-specs.