### PR TITLE
Removed overwrite of encode function

### DIFF
--- a/sgr_library/api/data_point_api.py
+++ b/sgr_library/api/data_point_api.py
@@ -76,7 +76,7 @@ class DataPoint(Generic[T]):
     async def write(self, data: T):
         value = self._converter.to_device(data)
         if self._validator.validate(value):
-            await self._protocol.write(value)
+            return await self._protocol.write(value)
         raise Exception("invalid data to write to device")
 
     def unit(self) -> SubSetUnits:

--- a/sgr_library/payload_decoder.py
+++ b/sgr_library/payload_decoder.py
@@ -70,7 +70,7 @@ class PayloadBuilder(BinaryPayloadBuilder):
     def __init__(self, *args, **kwarg):
         super().__init__(*args, **kwarg)
 
-    def encode(self, value: float, modbus_type: str, rounding: RoundingScheme):
+    def sgr_encode(self, value: float, modbus_type: str, rounding: RoundingScheme) -> 'PayloadBuilder':
         """
         :param modbus_type: 'int8', 'int8_u', 'int16', 'int16_u', 'int32', 'int32_u', 'int64', 'int64_u', 'float16', 'float32', 'float64', 'string'
         """
@@ -101,3 +101,4 @@ class PayloadBuilder(BinaryPayloadBuilder):
             self.add_string(round_to_int(value, rounding))
         else:
             print('Unknown modbus type "%s"', modbus_type)
+        return self


### PR DESCRIPTION
This PR addresses an issue where the `PayloadBuilder` was overwriting the `encode` function of the `BinaryPayloadBuilder`, leading to the error described in issue #32. Additionally, it resolves a bug in the datapoint write variable that consistently triggered an error due to a missing return statement.

@d1msk1y 
please confirm that this pr fixes your issue

fixes #32