### PR TITLE
Improved Github actions to build PyPi packages

### DIFF
--- a/.github/workflows/release-commhandler.yml
+++ b/.github/workflows/release-commhandler.yml
@@ -1,0 +1,84 @@
+name: Release Python SGrCommhandler
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to checkout and build'
+        required: true
+      semver:
+        description: 'Package version to deploy'
+        required: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    outputs:
+      original_tag: ${{ steps.set_tag.outputs.original_tag}}
+      semver: ${{ steps.set_tag.outputs.semver}}
+    steps:
+      - name: Set tag
+        id: set_tag
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "Original tag: ${{ github.event.inputs.tag }}"
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            echo "Original tag: ${{ github.event.client_payload.tag }}"
+            TAG="${{ github.event.client_payload.tag }}"
+          fi
+          if [ -z "${{ github.event.inputs.semver }}" ]; then
+            if [[ "${TAG}" =~ ^"v" ]]; then
+              SEMVER="${TAG:1}"  # This removes the first character, assuming it's 'v'
+            else
+              SEMVER="${TAG}"
+            fi
+          else
+            SEMVER="${{ github.event.inputs.semver }}"
+          fi
+          echo "Semver: $SEMVER"
+          echo "Tag: $TAG"
+          echo "::set-output name=original_tag::$TAG"
+          echo "::set-output name=semver::$SEMVER"
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel twine setuptools
+
+      - name: Check Python version
+        run: |
+          python --version
+
+      - name: Checkout SGrPython Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.set_tag.outputs.original_tag }}
+
+      - name: Modify Commhandler Setup File
+        working-directory: commhandler
+        run: |
+          sed -Ei "s/version=\"[^\"]+\",/version=\"${{ steps.set_tag.outputs.semver }}\",/" setup.py
+          cat setup.py
+          echo ${{ steps.set_tag.outputs.original_tag }}
+
+      - name: Install Build Dependencies
+        working-directory: commhandler
+        run: |
+          pip install -r requirements-dev.txt
+          pip install -r requirements.txt
+
+      - name: Build Commhandler Package
+        working-directory: commhandler
+        run: python setup.py sdist bdist_wheel
+
+      - name: Publish Commhandler Package to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.12.4
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: commhandler/dist/

--- a/.github/workflows/release-commhandler.yml
+++ b/.github/workflows/release-commhandler.yml
@@ -78,7 +78,6 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run Commhandler Tests
-        if: ${{ false }}
         working-directory: commhandler
         run: pytest
 

--- a/.github/workflows/release-commhandler.yml
+++ b/.github/workflows/release-commhandler.yml
@@ -78,6 +78,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run Commhandler Tests
+        if: ${{ false }}
         working-directory: commhandler
         run: pytest
 
@@ -87,7 +88,7 @@ jobs:
 
       - name: Publish Commhandler Package to PyPI
         # publish after committing to master or creating tag commhandler-{version}
-        if: success() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/commhandler-'))
+        if: success() && (github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/commhandler-'))
         uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release-commhandler.yml
+++ b/.github/workflows/release-commhandler.yml
@@ -1,6 +1,9 @@
 name: Release Python SGrCommhandler
 
 on:
+  push:
+    branches:
+      - master
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/release-commhandler.yml
+++ b/.github/workflows/release-commhandler.yml
@@ -2,8 +2,9 @@ name: Release Python SGrCommhandler
 
 on:
   push:
-    branches:
-      - master
+    paths:
+      - '.github/workflows/release-commhandler.yml'
+      - 'commhandler/**'
   workflow_dispatch:
     inputs:
       tag:
@@ -76,11 +77,17 @@ jobs:
           pip install -r requirements-dev.txt
           pip install -r requirements.txt
 
+      - name: Run Commhandler Tests
+        working-directory: commhandler
+        run: pytest
+
       - name: Build Commhandler Package
         working-directory: commhandler
         run: python setup.py sdist bdist_wheel
 
       - name: Publish Commhandler Package to PyPI
+        # publish after committing to master or creating tag commhandler-{version}
+        if: success() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/commhandler-'))
         uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release-specification.yml
+++ b/.github/workflows/release-specification.yml
@@ -75,6 +75,10 @@ jobs:
         working-directory: SGrPython/specification/src
         run: xsdata generate ../../../SGrSpecifications/SchemaDatabase/SGr -r --package sgr_specification.v0
 
+      - name: Copy specification schema files
+        working-directory: SGrPython/specification/src/sgr_schema
+        run: cp -fR ../../../../SGrSpecifications/SchemaDatabase/SGr/* .
+
       - name: Check SGrPython Directory
         run: ls SGrPython
 

--- a/.github/workflows/release-specification.yml
+++ b/.github/workflows/release-specification.yml
@@ -8,6 +8,9 @@ on:
       tag:
         description: 'Tag to checkout and build'
         required: true
+      semver:
+        description: 'Package version to deploy'
+        required: false
 
 jobs:
   build-and-deploy:
@@ -27,10 +30,14 @@ jobs:
             echo "Original tag: ${{ github.event.client_payload.tag }}"
             TAG="${{ github.event.client_payload.tag }}"
           fi
-          if [[ "${TAG}" =~ ^"v" ]]; then
-            SEMVER="${TAG:1}"  # This removes the first character, assuming it's 'v'
+          if [ -z "${{ github.event.inputs.semver }}" ]; then
+            if [[ "${TAG}" =~ ^"v" ]]; then
+              SEMVER="${TAG:1}"  # This removes the first character, assuming it's 'v'
+            else
+              SEMVER="${TAG}"
+            fi
           else
-            SEMVER="${TAG}"
+            SEMVER="${{ github.event.inputs.semver }}"
           fi
           echo "Semver: $SEMVER"
           echo "Tag: $TAG"
@@ -74,7 +81,7 @@ jobs:
       - name: Modify Specification Setup File
         working-directory: SGrPython/specification
         run: |
-          sed -Ei "s/version=\"[^\\"]+\",/version=\"${{ steps.set_tag.outputs.semver }}\",/" setup.py
+          sed -Ei "s/version=\"[^\"]+\",/version=\"${{ steps.set_tag.outputs.semver }}\",/" setup.py
           cat setup.py
           echo ${{ steps.set_tag.outputs.original_tag }}
 

--- a/.github/workflows/release-specification.yml
+++ b/.github/workflows/release-specification.yml
@@ -84,14 +84,16 @@ jobs:
           password: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Bump Patch Version
+        if: ${{ false }}
         id: version_bump
-        working-directory: SGrPython
+        working-directory: SGrPython/commhandler
         run: |
           sed -i "s/SGrSpecificationPythontks4r==.*/SGrSpecificationPythontks4r==${{ steps.set_tag.outputs.semver }}/g" requirements.txt
           echo "Updated version to ${{ steps.set_tag.outputs.semver }} in requirements.txt"
           cat requirements.txt
 
       - name: Create a new Branch
+        if: ${{ false }}
         working-directory: SGrPython
         run: |
           git checkout -b version-update-${{ steps.set_tag.outputs.semver }}
@@ -102,6 +104,7 @@ jobs:
           git push --set-upstream origin version-update-${{ steps.set_tag.outputs.semver }}
 
       - name: Create Pull Request
+        if: ${{ false }}
         uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/release-specification.yml
+++ b/.github/workflows/release-specification.yml
@@ -27,12 +27,16 @@ jobs:
             echo "Original tag: ${{ github.event.client_payload.tag }}"
             TAG="${{ github.event.client_payload.tag }}"
           fi
-          SEMVER="${TAG:1}"  # This removes the first character, assuming it's 'v'
+          if [[ "${TAG}" =~ ^"v" ]]; then
+            SEMVER="${TAG:1}"  # This removes the first character, assuming it's 'v'
+          else
+            SEMVER="${TAG}"
+          fi
           echo "Semver: $SEMVER"
           echo "Tag: $TAG"
           echo "::set-output name=original_tag::$TAG"
           echo "::set-output name=semver::$SEMVER"
-#
+
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -70,7 +74,7 @@ jobs:
       - name: Modify Specification Setup File
         working-directory: SGrPython/specification
         run: |
-          sed -Ei "s/version='[^\']+',/version='${{ steps.set_tag.outputs.semver }}',/" setup.py
+          sed -Ei "s/version=\"[^\\"]+\",/version=\"${{ steps.set_tag.outputs.semver }}\",/" setup.py
           cat setup.py
           echo ${{ steps.set_tag.outputs.original_tag }}
 

--- a/.github/workflows/release-specification.yml
+++ b/.github/workflows/release-specification.yml
@@ -90,9 +90,10 @@ jobs:
         run: python setup.py sdist bdist_wheel
 
       - name: Publish Specification Package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.4.2
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: SGrPython/specification/dist/
 
       - name: Bump Patch Version
         if: ${{ false }}

--- a/commhandler/pyproject.toml
+++ b/commhandler/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "aiohttp>=3.0.0,<4.0.0",
     "certifi",
     "cachetools>=5.0.0,<6.0.0",
-    "SGrSpecificationPythontks4r==0.3.0",
+    "SGrSpecificationPythontks4r~=2.0",
 ]
 [tool.pyright]
 exclude = ["**/node_modules", "**/__pycache__", "example"]

--- a/commhandler/pyproject.toml
+++ b/commhandler/pyproject.toml
@@ -22,10 +22,11 @@ dependencies = [
     "cachetools>=5.0.0,<6.0.0",
     "SGrSpecificationPythontks4r~=2.0",
 ]
-[tool.pyright]
-exclude = ["**/node_modules", "**/__pycache__", "example"]
 
-[tool.pytest]
-pythonpath = 'src'
-asyncio_default_fixture_loop_scope = 'session'
-asyncio_mode = 'strict'
+[tool.pyright]
+exclude = ["**/node_modules", "**/__pycache__", "examples"]
+
+[tool.pytest.ini_options]
+pythonpath = [ "src" ]
+asyncio_default_fixture_loop_scope = "session"
+asyncio_mode = "strict"

--- a/commhandler/requirements.txt
+++ b/commhandler/requirements.txt
@@ -6,4 +6,4 @@ xsdata>=22.0.0,<23.0.0
 aiohttp>=3.0.0,<4.0.0
 certifi
 cachetools>=5.0.0,<6.0.0
-SGrSpecificationPythontks4r==0.3.0
+SGrSpecificationPythontks4r~=2.0

--- a/specification/pyproject.toml
+++ b/specification/pyproject.toml
@@ -13,4 +13,9 @@ authors = [{ name = "Robin Schoch" }]
 urls = { "Homepage" = "https://github.com/SmartGridready/SGrSpecifications" }
 dependencies = []
 
-[tool.ruff]
+[tool.setuptools]
+include-package-data = true
+
+# include XSD from package directory and 1 sub-directory
+[tool.setuptools.package-data]
+sgr_schema = ["*.xsd", "*/*.xsd"]

--- a/specification/setup.py
+++ b/specification/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="SGrSpecificationPythontks4r",  # use SGrSpecificationPythontks4r until organization has been created, then change to sgr-specification
-    version="0.3.0",
+    version="2.0.0",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     install_requires=[],

--- a/specification/src/sgr_schema/.gitignore
+++ b/specification/src/sgr_schema/.gitignore
@@ -1,0 +1,2 @@
+# schemas
+*.xsd

--- a/specification/src/sgr_schema/__init__.py
+++ b/specification/src/sgr_schema/__init__.py
@@ -1,0 +1,1 @@
+# nothing here


### PR DESCRIPTION
- specification release works when target package version is entered manually (version format conflict)
- commhandler release works when target package version is entered manually (cannot use git hash in version)
- specification package now includes XSD files

**please SQUASH merge**