### PR TITLE
fix issue #58: parameter names in config file converted to lowercase

### DIFF
--- a/commhandler/src/sgr_commhandler/device_builder.py
+++ b/commhandler/src/sgr_commhandler/device_builder.py
@@ -162,7 +162,8 @@ class DeviceBuilder:
             try:
                 prop_path = str(self._properties_source)
                 logger.debug(f'getting properties from file {prop_path}')
-                config = configparser.ConfigParser()
+                config = configparser.RawConfigParser()
+                config.optionxform = lambda option: option
                 config.read(prop_path)
                 properties = {}
                 for section_name, section in config.items():


### PR DESCRIPTION
change the standard options for configparser in order to preserve uppercase characters in parameter names such as baseUri